### PR TITLE
Iterative benchadapt adapter thats calls arrowbench benchmarks one at a time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     RcppSimdJson,
     readr,
     vroom
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE, load = "source")
 Collate: 
     'benchmark.R'

--- a/R/bm-read-file.R
+++ b/R/bm-read-file.R
@@ -8,7 +8,7 @@
 #'
 #' @export
 read_file <- Benchmark("read_file",
-  setup = function(source = names(known_sources),
+  setup = function(source = c("fanniemae_2016Q4", "nyctaxi_2010-01"),
                    # TODO: break out feather_v1 and feather_v2, feather_v2 only in >= 0.17
                    format = c("parquet", "feather"),
                    compression = c("uncompressed", "snappy", "lz4"),

--- a/R/bm-write-file.R
+++ b/R/bm-write-file.R
@@ -8,7 +8,7 @@
 #'
 #' @export
 write_file <- Benchmark("write_file",
-  setup = function(source = names(known_sources),
+  setup = function(source = c("fanniemae_2016Q4", "nyctaxi_2010-01"),
                    format = c("parquet", "feather"),
                    compression = c("uncompressed", "snappy", "lz4"),
                    input = c("arrow_table", "data_frame")) {

--- a/inst/arrowbench
+++ b/inst/arrowbench
@@ -1,0 +1,61 @@
+#!/usr/bin/env Rscript
+library(arrowbench)
+
+
+args <- commandArgs(trailingOnly = TRUE)
+
+benchmark_list <- list(
+  read_file,
+  write_file
+)
+names(benchmark_list) <- vapply(benchmark_list, function(x) x$name, character(1))
+
+benchmark_command_json <- benchmark_list |>
+  purrr::imap(~cbind(data.frame(bm = .y), arrowbench:::default_params(.x))) |>
+  lapply(function(x) split(x, seq(nrow(x)))) |>
+  lapply(unname) |>
+  purrr::flatten() |>
+  lapply(as.list) |>
+  jsonlite::toJSON(auto_unbox = TRUE)
+
+
+switch (args[[1]],
+  "help" = if (length(args) == 1) {
+    cat(
+      "List and run arrowbench benchmarks",
+      "",
+      "Commands:",
+      "    help [run|list]",
+      "    list",
+      "    run BENCHMARK [OPTIONS]",
+      sep = "\n"
+    )
+  } else if (length(args) >= 2 && args[[2]] == "list") {
+    cat(
+      "List available benchmarks in a JSON list.",
+      "",
+      "Usage:",
+      "    arrowbench list",
+      sep = "\n"
+    )
+  } else if (length(args) >= 2 && args[[2]] == "run") {
+    cat(
+      "Run a benchmark.",
+      "",
+      "Usage:",
+      "    arrowbench run BENCHMARK [OPTIONS]",
+      "",
+      "Example:",
+      "    arrowbench run read_file n_iter=2",
+      sep = "\n"
+    )
+  } else {
+    cat("Help topic not found", sep = "\n")
+  },
+  "list" = cat(benchmark_command_json),
+  "run" = {
+    arg_list <- jsonlite::fromJSON(args[[2]])
+    arg_list$bm <- parse(text = arg_list$bm)[[1]]
+    cat(suppressWarnings(do.call(run_one, arg_list)$to_publishable_json()))
+  }
+)

--- a/inst/arrowbench-adapter.py
+++ b/inst/arrowbench-adapter.py
@@ -1,0 +1,68 @@
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Generator, List
+
+from benchadapt import BenchmarkResult
+from benchadapt.adapters import GeneratorAdapter
+from benchadapt.log import log
+
+
+class ArrowbenchAdapter(GeneratorAdapter):
+    """
+    An adapter for running arrowbench benchmarks
+    """
+
+    def __init__(
+        self,
+        arrowbench_executable: str,
+        result_fields_override: Dict[str, Any] = None,
+        result_fields_append: Dict[str, Any] = None,
+    ) -> None:
+        self.arrowbench = arrowbench_executable
+
+        super().__init__(
+            generator=self.run_arrowbench,
+            result_fields_override=result_fields_override,
+            result_fields_append=result_fields_append,
+        )
+
+    def list_benchmarks(self) -> List[Dict[str, Any]]:
+        """
+        Get list of benchmark commands from arrowbench CLI
+
+        Returns
+        -------
+        A list of dicts that can be passed to `arrowbench run`
+        """
+        res = subprocess.run(f"{self.arrowbench} list", shell=True, capture_output=True)
+        return json.loads(res.stdout.decode())
+
+    def run_arrowbench(self) -> Generator[BenchmarkResult, None, None]:
+        """
+        A generator that uses the arrowbench CLI to list available benchmarks,
+        then iterate through the list, running each and yielding the result.
+        """
+        benchmarks = self.list_benchmarks()
+        # subset for demo purposes:
+        benchmarks = benchmarks[:10]
+        for benchmark in benchmarks:
+            command = f"{self.arrowbench} run '{json.dumps(benchmark)}'"
+            log.info(f"Running `{command}`")
+            res = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+            )
+            dict_result = json.loads(res.stdout.decode())
+            result = BenchmarkResult(**dict_result)
+            yield result
+
+
+if __name__ == "__main__":
+    adapter = ArrowbenchAdapter(
+        arrowbench_executable=Path(__file__).resolve().parent / "arrowbench",
+        result_fields_override={"run_reason": "test"},
+    )
+    for result in adapter.run():
+        print(result)

--- a/man/Benchmark.Rd
+++ b/man/Benchmark.Rd
@@ -63,14 +63,16 @@ Define a Benchmark
 }
 \section{Evaluation}{
 
-A \code{Benchmark} is evaluated something like:\preformatted{env <- bm$setup(param1 = "value", param2 = "value")
+A \code{Benchmark} is evaluated something like:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{env <- bm$setup(param1 = "value", param2 = "value")
 for (i in seq_len(n_iter)) \{
   eval(bm$before_each, envir = env)
   measure(eval(bm$run, envir = env))
   eval(bm$after_each, envir = env)
 \}
 eval(bm$teardown, envir = env)
-}
+}\if{html}{\out{</div>}}
 
 Benchmarks should run a single combination of parameters. Running across
 a range of parameter combinations is handled by the runner, not the functions

--- a/man/R6Point1Class.Rd
+++ b/man/R6Point1Class.Rd
@@ -26,7 +26,9 @@ Functions are evaluated in the environment of \code{Class}, so you can refer to 
 Sometimes we want static/class methods/attributes that can be accessed from
 the class (e.g. \code{MyR6Class$my_static_method()}) instead of an instance of
 that class (e.g. \code{MyR6Class$new(...)$my_normal_method()}). As individual
-classes are environments, these can be added after the fact like so:\if{html}{\out{<div class="sourceCode r">}}\preformatted{MyR6Class <- R6Class(...)
+classes are environments, these can be added after the fact like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{MyR6Class <- R6Class(...)
 MyR6Class$my_static_method <- function(x) ...
 }\if{html}{\out{</div>}}
 


### PR DESCRIPTION
Mocks up an iterative benchadapt adapter using `GeneratorAdapter` from https://github.com/conbench/conbench/pull/406 to call arrowbench benchmarks one at a time. Changes:

1. Adjusts `BenchmarkResult` to allow it to output JSON with fields arranged appropriately for `benchadapt.BenchmarkResult` (and therefore the conbench API). A little fast-and-dirty; there's work to be done to make sure we're populating everything what we want to, since all of this was getting populated by voltrondata_labs/benchmarks and the conbench runner before.
2. Restricts the default sources for `read_file` and `write_file` to match the defaults in labs/benchmarks. `names(known_sources)` was working fine except for `tpch`, for which the benchmarks don't have additional code to iterate over tables.
3. Adds an R executable CLI at `inst/arrowbench` that can:
  a. produce a JSON list of dicts of args suitable for running a case via `run_one()`, e.g. `{"bm": "read_file", "source": "fanniemae_2016Q4", "format": "parquet", "compression": "uncompressed", "output": "arrow_table", "cpu_count": 1}`
  b. run a case with `run_one()` when passed a dict of args like the list command produces and cat the cleaned JSON results
4. Adds an adapter that inherits from `GeneratorAdapter`. It is initialized with a path to the CLI created in 3., and when run, hits the CLI to list benchmark cases, then iterates through them (subset to the first 10 for demo purposes), runs each, parses the result JSON and inserts it into a `BenchmarkResult` object, and yields that. When called, the adapter will post each result before moving on to the next iteration.

This needs careful polish before replacing labs/benchmarks for R benchmark running to ensure that our metadata is consistent and won't break histories, but does show how R benchmarks could work with adapters.