### PR TITLE
[DO NOT MERGE] Align results with those of labs/benchmarks and the Conbench API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: arrowbench
 Type: Package
 Title: Tools for Continuous and Interactive Benchmarking
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Neal", "Richardson", email = "neal.p.richardson@gmail.com", role = "aut"),
     person("Jonathan", "Keane", email = "jkeane@gmail.com", role = c("aut", "cre"))
@@ -43,7 +43,7 @@ Suggests:
     RcppSimdJson,
     readr,
     vroom
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE, load = "source")
 Collate: 
     'benchmark.R'

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -86,6 +86,12 @@
 #' single case and returning an integer version for the case, or `NULL` to not
 #' append a version; `NA` will raise an error. Changes to version will break
 #' conbench history for a case.
+#' @param batch_id_fun A unary function which takes a dataframe of parameters and
+#' returns a character vector to use as `batch_id` of length 1 or `nrow(params)`
+#' @param tags_fun A unary function which takes a named list of setup parameters
+#' for a single case and returns a named list of tags to send to Conbench for that
+#' case. Can be overwritten to add static tags or postprocess parameters into more
+#' readable forms.
 #' @param packages_used function taking a `data.frame` of setup parameters and
 #' returning a vector of R package names required
 #' @param ... additional attributes or functions, possibly called in `setup()`.
@@ -100,6 +106,8 @@ Benchmark <- function(name,
                       teardown = TRUE,
                       valid_params = function(params) params,
                       case_version = function(params) NULL,
+                      batch_id_fun = function(params) uuid(),
+                      tags_fun = function(params) params,
                       packages_used = function(params) "arrow",
                       ...) {
   stopifnot(is.character(name))
@@ -113,6 +121,8 @@ Benchmark <- function(name,
       teardown = substitute(teardown),
       valid_params = valid_params,
       case_version = case_version,
+      batch_id_fun = batch_id_fun,
+      tags_fun = tags_fun,
       packages_used = packages_used,
       ...),
     class = "Benchmark"
@@ -164,12 +174,12 @@ default_params <- function(bm, ...) {
 #' error status
 #'
 #' @param run An instance of `BenchmarkResults` as returned by `run_benchmark`
-#' or `BenchmarkResult` or `BenchmarkFailure` as returned by `run_one` and `run_bm`
+#' or `BenchmarkResult` as returned by `run_one` and `run_bm`
 #' @return a tibble
 #' @export
 get_params_summary <- function(run) {
-  if (!inherits(run, c("BenchmarkResults", "BenchmarkResult", "BenchmarkFailure"))) {
-    stop("run objects need to be of class BenchmarkResults, BenchmarkResult, or BenchmarkFailure")
+  if (!inherits(run, c("BenchmarkResults", "BenchmarkResult"))) {
+    stop("run objects need to be of class BenchmarkResults or BenchmarkResult")
   }
   run$params_summary
 }

--- a/R/bm-dataset-taxi-parquet.R
+++ b/R/bm-dataset-taxi-parquet.R
@@ -4,7 +4,7 @@
 #' * `query` Name of a known query to run; see `dataset_taxi_parquet$cases`
 #'
 #' @export
-dataset_taxi_parquet <- Benchmark("dataset_taxi_parquet",
+dataset_taxi_parquet <- Benchmark("partitioned-dataset-filter",
   setup = function(query = names(dataset_taxi_parquet$cases)) {
     library("dplyr", warn.conflicts = FALSE)
     dataset <- ensure_dataset("taxi_parquet")

--- a/R/bm-df-to-table.R
+++ b/R/bm-df-to-table.R
@@ -6,8 +6,13 @@
 #' * `source` A known-file id to use (it will be read in to a data.frame first)
 #'
 #' @export
-df_to_table <- Benchmark("df_to_table",
-  setup = function(source = names(known_sources)) {
+df_to_table <- Benchmark("dataframe-to-table",
+  setup = function(source = c("chi_traffic_2020_Q1",
+                              "type_strings",
+                              "type_dict",
+                              "type_integers",
+                              "type_floats",
+                              "type_nested")) {
     source <- ensure_source(source)
     result_dim <- get_source_attr(source, "dim")
     # Make sure that we're not (accidentally) creating altrep vectors which will

--- a/R/bm-tpc-h.R
+++ b/R/bm-tpc-h.R
@@ -14,7 +14,7 @@
 #'
 #' @importFrom waldo compare
 #' @export
-tpc_h <- Benchmark("tpc_h",
+tpc_h <- Benchmark("tpch",
   setup = function(engine = "arrow",
                    query_id = 1:22,
                    format = c("native", "parquet"),
@@ -134,6 +134,14 @@ tpc_h <- Benchmark("tpc_h",
       # TODO: do this?
       ( params$engine == "dplyr" & params$format == "native" )
     params[!drop,]
+  },
+  batch_id_fun = function(params) {
+    batch_id <- uuid()
+    paste0(batch_id, "-", params$scale_factor, substr(params$format, 1, 1))
+  },
+  tags_fun = function(params) {
+    params$query_id <- sprintf("TPCH-%02d", params$query_id)
+    params
   },
   # packages used when specific formats are used
   packages_used = function(params) {

--- a/R/bm-write-file.R
+++ b/R/bm-write-file.R
@@ -2,31 +2,31 @@
 #'
 #' @section Parameters:
 #' * `source` A known-file id, or a CSV(?) file path to read in
-#' * `format` One of `c("parquet", "feather", "fst")`
+#' * `file_type` One of `c("parquet", "feather", "fst")`
 #' * `compression` One of the values: `r paste(known_compressions, collapse = ", ")`
-#' * `input` One of `c("arrow_table", "data_frame")`
+#' * `input_type` One of `c("arrow_table", "data_frame")`
 #'
 #' @export
-write_file <- Benchmark("write_file",
-  setup = function(source = names(known_sources),
-                   format = c("parquet", "feather"),
+write_file <- Benchmark("file-write",
+  setup = function(source = c("fanniemae_2016Q4", "nyctaxi_2010-01"),
+                   file_type = c("parquet", "feather"),
                    compression = c("uncompressed", "snappy", "lz4"),
-                   input = c("arrow_table", "data_frame")) {
+                   input_type = c("arrow_table", "data_frame")) {
     # source defaults are retrieved from the function definition (all available
     # known_sources) and then read the source in as a data.frame
     source <- ensure_source(source)
-    df <- read_source(source, as_data_frame = match.arg(input) == "data_frame")
-    # format defaults to parquet or feather, but can accept fst as well
-    format <- match.arg(format, c("parquet", "feather", "fst"))
+    df <- read_source(source, as_data_frame = match.arg(input_type) == "data_frame")
+    # file_type defaults to parquet or feather, but can accept fst as well
+    file_type <- match.arg(file_type, c("parquet", "feather", "fst"))
 
     # Map string param name to functions
-    write_func <- get_write_function(format, compression)
+    write_func <- get_write_function(file_type, compression)
 
     # put the necessary variables into a BenchmarkEnvironment to be used when
     # the benchmark is running.
     BenchEnvironment(
       write_func = write_func,
-      format = format,
+      file_type = file_type,
       source = source,
       df = df
     )
@@ -46,41 +46,41 @@ write_file <- Benchmark("write_file",
   },
   # validate that the parameters given are compatible
   valid_params = function(params) {
-    # make sure that the format and the compression is compatible
-    # and fst doesn't have arrow_table input
-    drop <- !validate_format(params$format, params$compression) |
-      params$format == "fst" & params$input == "arrow_table"
+    # make sure that the file_type and the compression is compatible
+    # and fst doesn't have arrow_table input_type
+    drop <- !validate_format(params$file_type, params$compression) |
+      params$file_type == "fst" & params$input_type == "arrow_table"
     params[!drop,]
   },
-  # packages used when specific formats are used
+  # packages used when specific file_types are used
   packages_used = function(params) {
     pkg_map <- c(
       "feather" = "arrow",
       "parquet" = "arrow",
       "fst" = "fst"
     )
-    pkg_map[params$format]
+    pkg_map[params$file_type]
   }
 )
 
 #' Get a writer
 #'
-#' @param format format to write
+#' @param file_type file_type to write
 #' @param compression compression to use
 #'
 #' @return the write function to use
 #' @export
-get_write_function <- function(format, compression) {
+get_write_function <- function(file_type, compression) {
   force(compression)
-  if (format == "feather") {
+  if (file_type == "feather") {
     return(function(...) arrow::write_feather(..., compression = compression))
-  } else if (format == "parquet") {
+  } else if (file_type == "parquet") {
     return(function(...) arrow::write_parquet(..., compression = compression))
-  } else if (format == "fst") {
+  } else if (file_type == "fst") {
     # fst is always zstd, just a question of what level of compression
     level <- ifelse(compression == "uncompressed", 0, 50)
     return(function(...) fst::write_fst(..., compress = level))
   } else {
-    stop("Unsupported format: ", format, call. = FALSE)
+    stop("Unsupported file_type: ", file_type, call. = FALSE)
   }
 }

--- a/R/util.R
+++ b/R/util.R
@@ -1,3 +1,21 @@
+# Equivalent to Python:
+# `datetime.datetime.now(datetime.timezone.utc).isoformat()`
+utc_now_iso_format <- function() {
+  withr::with_envvar(list(TZ = "UTC"), {
+    utc_now = Sys.time()
+  })
+
+  withr::with_options(list(digits.secs = 6L), {
+    format(utc_now, format = "%FT%H:%M:%OS%z")
+  })
+}
+
+# returns a single hex UUID
+uuid <- function() {
+  paste(uuid::UUIDgenerate(output = "raw"), collapse = "")
+}
+
+
 #' @importFrom purrr map_int
 #' @importFrom stats setNames
 get_default_args <- function(FUN) {

--- a/man/Benchmark.Rd
+++ b/man/Benchmark.Rd
@@ -13,6 +13,8 @@ Benchmark(
   teardown = TRUE,
   valid_params = function(params) params,
   case_version = function(params) NULL,
+  batch_id_fun = function(params) uuid(),
+  tags_fun = function(params) params,
   packages_used = function(params) "arrow",
   ...
 )
@@ -50,6 +52,14 @@ single case and returning an integer version for the case, or \code{NULL} to not
 append a version; \code{NA} will raise an error. Changes to version will break
 conbench history for a case.}
 
+\item{batch_id_fun}{A unary function which takes a dataframe of parameters and
+returns a character vector to use as \code{batch_id} of length 1 or \code{nrow(params)}}
+
+\item{tags_fun}{A unary function which takes a named list of setup parameters
+for a single case and returns a named list of tags to send to Conbench for that
+case. Can be overwritten to add static tags or postprocess parameters into more
+readable forms.}
+
 \item{packages_used}{function taking a \code{data.frame} of setup parameters and
 returning a vector of R package names required}
 
@@ -63,14 +73,16 @@ Define a Benchmark
 }
 \section{Evaluation}{
 
-A \code{Benchmark} is evaluated something like:\preformatted{env <- bm$setup(param1 = "value", param2 = "value")
+A \code{Benchmark} is evaluated something like:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{env <- bm$setup(param1 = "value", param2 = "value")
 for (i in seq_len(n_iter)) \{
   eval(bm$before_each, envir = env)
   measure(eval(bm$run, envir = env))
   eval(bm$after_each, envir = env)
 \}
 eval(bm$teardown, envir = env)
-}
+}\if{html}{\out{</div>}}
 
 Benchmarks should run a single combination of parameters. Running across
 a range of parameter combinations is handled by the runner, not the functions

--- a/man/R6Point1Class.Rd
+++ b/man/R6Point1Class.Rd
@@ -26,7 +26,9 @@ Functions are evaluated in the environment of \code{Class}, so you can refer to 
 Sometimes we want static/class methods/attributes that can be accessed from
 the class (e.g. \code{MyR6Class$my_static_method()}) instead of an instance of
 that class (e.g. \code{MyR6Class$new(...)$my_normal_method()}). As individual
-classes are environments, these can be added after the fact like so:\if{html}{\out{<div class="sourceCode r">}}\preformatted{MyR6Class <- R6Class(...)
+classes are environments, these can be added after the fact like so:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{MyR6Class <- R6Class(...)
 MyR6Class$my_static_method <- function(x) ...
 }\if{html}{\out{</div>}}
 

--- a/man/array_altrep_materialization.Rd
+++ b/man/array_altrep_materialization.Rd
@@ -5,7 +5,7 @@
 \alias{array_altrep_materialization}
 \title{Benchmark for materializing an altrep Arrow array}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 array_altrep_materialization

--- a/man/array_to_vector.Rd
+++ b/man/array_to_vector.Rd
@@ -5,7 +5,7 @@
 \alias{array_to_vector}
 \title{Benchmark for reading an Arrow array to a vector}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 array_to_vector

--- a/man/dataset_taxi_2013.Rd
+++ b/man/dataset_taxi_2013.Rd
@@ -5,7 +5,7 @@
 \alias{dataset_taxi_2013}
 \title{Benchmark Taxi 2013 dataset reading}
 \format{
-An object of class \code{Benchmark} of length 10.
+An object of class \code{Benchmark} of length 12.
 }
 \usage{
 dataset_taxi_2013

--- a/man/dataset_taxi_parquet.Rd
+++ b/man/dataset_taxi_parquet.Rd
@@ -5,7 +5,7 @@
 \alias{dataset_taxi_parquet}
 \title{Benchmark Taxi dataset (Parquet) reading}
 \format{
-An object of class \code{Benchmark} of length 10.
+An object of class \code{Benchmark} of length 12.
 }
 \usage{
 dataset_taxi_parquet

--- a/man/df_to_table.Rd
+++ b/man/df_to_table.Rd
@@ -5,7 +5,7 @@
 \alias{df_to_table}
 \title{Benchmark for reading a data.frame into an Arrow table}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 df_to_table

--- a/man/get_params_summary.Rd
+++ b/man/get_params_summary.Rd
@@ -8,7 +8,7 @@ get_params_summary(run)
 }
 \arguments{
 \item{run}{An instance of \code{BenchmarkResults} as returned by \code{run_benchmark}
-or \code{BenchmarkResult} or \code{BenchmarkFailure} as returned by \code{run_one} and \code{run_bm}}
+or \code{BenchmarkResult} as returned by \code{run_one} and \code{run_bm}}
 }
 \value{
 a tibble

--- a/man/get_read_function.Rd
+++ b/man/get_read_function.Rd
@@ -4,10 +4,10 @@
 \alias{get_read_function}
 \title{Get a reader}
 \usage{
-get_read_function(format)
+get_read_function(file_type)
 }
 \arguments{
-\item{format}{what format to read}
+\item{file_type}{what file_type to read}
 }
 \value{
 the read function to use

--- a/man/get_write_function.Rd
+++ b/man/get_write_function.Rd
@@ -15,6 +15,8 @@ get_write_function(format, compression, chunk_size = NULL)
 
 \item{chunk_size}{the size of chunks to write (default: NULL, the default for
 the format)}
+
+\item{file_type}{file_type to write}
 }
 \value{
 the write function to use

--- a/man/placebo.Rd
+++ b/man/placebo.Rd
@@ -5,7 +5,7 @@
 \alias{placebo}
 \title{Placebo benchmark for testing}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 placebo

--- a/man/read_csv.Rd
+++ b/man/read_csv.Rd
@@ -5,7 +5,7 @@
 \alias{read_csv}
 \title{Benchmark CSV reading}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 read_csv

--- a/man/read_file.Rd
+++ b/man/read_file.Rd
@@ -5,7 +5,7 @@
 \alias{read_file}
 \title{Benchmark file reading}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 read_file
@@ -17,9 +17,9 @@ Benchmark file reading
 
 \itemize{
 \item \code{source} A known-file id, or a CSV(?) file path to read in
-\item \code{format} One of \code{c("parquet", "feather", "fst")}
+\item \code{file_type} One of \code{c("parquet", "feather", "fst")}
 \item \code{compression} One of the values: uncompressed, snappy, zstd, gzip, lz4, brotli, lzo, bz2
-\item \code{output} One of \code{c("arrow_table", "data_frame")}
+\item \code{output_type} One of \code{c("arrow_table", "data_frame")}
 }
 }
 

--- a/man/read_json.Rd
+++ b/man/read_json.Rd
@@ -5,7 +5,7 @@
 \alias{read_json}
 \title{Benchmark JSON reading}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 read_json

--- a/man/remote_dataset.Rd
+++ b/man/remote_dataset.Rd
@@ -5,7 +5,7 @@
 \alias{remote_dataset}
 \title{Remote (S3) dataset reading}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 remote_dataset

--- a/man/row_group_size.Rd
+++ b/man/row_group_size.Rd
@@ -5,7 +5,7 @@
 \alias{row_group_size}
 \title{Benchmark effect of parquet row group size}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 row_group_size

--- a/man/run_benchmark.Rd
+++ b/man/run_benchmark.Rd
@@ -38,8 +38,7 @@ run any that it cannot find.}
 }
 \value{
 A \code{BenchmarkResults} object, containing \code{results} attribute of a list
-of length \code{nrow(params)} each of those either a \code{BenchmarkResult} or
-\code{BenchmarkFalure} object.
+of length \code{nrow(params)}, each of those a \code{BenchmarkResult} object.
 For a simpler view of results, call \code{as.data.frame()} on it.
 }
 \description{

--- a/man/run_bm.Rd
+++ b/man/run_bm.Rd
@@ -4,7 +4,14 @@
 \alias{run_bm}
 \title{Execute a benchmark run}
 \usage{
-run_bm(bm, ..., n_iter = 1, profiling = FALSE, global_params = list())
+run_bm(
+  bm,
+  ...,
+  n_iter = 1,
+  batch_id = NULL,
+  profiling = FALSE,
+  global_params = list()
+)
 }
 \arguments{
 \item{bm}{\code{\link[=Benchmark]{Benchmark()}} object}
@@ -12,6 +19,8 @@ run_bm(bm, ..., n_iter = 1, profiling = FALSE, global_params = list())
 \item{...}{parameters passed to \code{bm$setup()}.}
 
 \item{n_iter}{integer number of iterations to replicate each benchmark}
+
+\item{batch_id}{a length 1 character vector to identify the batch}
 
 \item{profiling}{Logical: collect prof info? If \code{TRUE}, the result data will
 contain a \code{prof_file} field, which you can read in with

--- a/man/run_one.Rd
+++ b/man/run_one.Rd
@@ -8,6 +8,7 @@ run_one(
   bm,
   ...,
   n_iter = 1,
+  batch_id = NULL,
   dry_run = FALSE,
   profiling = FALSE,
   progress_bar = NULL,
@@ -21,6 +22,8 @@ run_one(
 \item{...}{parameters passed to \code{bm$setup()}.}
 
 \item{n_iter}{integer number of iterations to replicate each benchmark}
+
+\item{batch_id}{a length 1 character vector to identify the batch}
 
 \item{dry_run}{logical: just return the R source code that would be run in
 a subprocess? Default is \code{FALSE}, meaning that the benchmarks will be run.}
@@ -38,7 +41,7 @@ run any that it cannot find.}
 }
 \value{
 An instance of \code{BenchmarkResult}: an R6 object containing either
-"result" or "error".
+"stats" or "error".
 }
 \description{
 Run a Benchmark with a single set of parameters

--- a/man/table_to_df.Rd
+++ b/man/table_to_df.Rd
@@ -5,7 +5,7 @@
 \alias{table_to_df}
 \title{Benchmark for reading an Arrow table to a data.frame}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 table_to_df

--- a/man/tpc_h.Rd
+++ b/man/tpc_h.Rd
@@ -5,7 +5,7 @@
 \alias{tpc_h}
 \title{Benchmark TPC-H queries}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 tpc_h

--- a/man/write_csv.Rd
+++ b/man/write_csv.Rd
@@ -5,7 +5,7 @@
 \alias{write_csv}
 \title{Benchmark CSV writing}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 write_csv

--- a/man/write_file.Rd
+++ b/man/write_file.Rd
@@ -5,7 +5,7 @@
 \alias{write_file}
 \title{Benchmark file writing}
 \format{
-An object of class \code{Benchmark} of length 9.
+An object of class \code{Benchmark} of length 11.
 }
 \usage{
 write_file
@@ -17,9 +17,9 @@ Benchmark file writing
 
 \itemize{
 \item \code{source} A known-file id, or a CSV(?) file path to read in
-\item \code{format} One of \code{c("parquet", "feather", "fst")}
+\item \code{file_type} One of \code{c("parquet", "feather", "fst")}
 \item \code{compression} One of the values: uncompressed, snappy, zstd, gzip, lz4, brotli, lzo, bz2
-\item \code{input} One of \code{c("arrow_table", "data_frame")}
+\item \code{input_type} One of \code{c("arrow_table", "data_frame")}
 }
 }
 

--- a/tests/testthat/test-bm-dataset-taxi-2013.R
+++ b/tests/testthat/test-bm-dataset-taxi-2013.R
@@ -11,7 +11,7 @@ test_that("dataset_taxi_2013 exists", {
 test_that("dataset_taxi_2013 runs on sample data", {
   res <- run_benchmark(dataset_taxi_2013, dataset = "taxi_2013_sample", cpu_count = 1L)
 
-  lapply(res$results, function(result) {
+  lapply(res$optional_benchmark_info$results, function(result) {
     expect_s3_class(result, "BenchmarkResult")
     expect_gte(result$result$real, 0)
   })

--- a/tests/testthat/test-bm-read-file.R
+++ b/tests/testthat/test-bm-read-file.R
@@ -11,7 +11,7 @@ test_that("read_file validation", {
 
   # specifically feather+snappy is not a possibility
   expect_identical(
-    nrow(params[params$format == "feather" & params$compression == "snappy", ]),
+    nrow(params[params$file_type == "feather" & params$compression == "snappy", ]),
     0L
   )
 })

--- a/tests/testthat/test-bm-write-file.R
+++ b/tests/testthat/test-bm-write-file.R
@@ -5,9 +5,9 @@ test_that("write_file benchmark works", {
     run_benchmark(
       write_file,
       source = "nyctaxi_sample",
-      format = c("parquet", "feather"),
+      file_type = c("parquet", "feather"),
       compression = c("uncompressed", "snappy", "lz4"),
-      input = c("arrow_table", "data_frame")
+      type = c("arrow_table", "data_frame")
     ),
     "BenchmarkResults"
   )

--- a/tests/testthat/test-measure.R
+++ b/tests/testthat/test-measure.R
@@ -3,10 +3,10 @@ test_that("with_gc_info + errors", {
   # directly because of how testthat alters how errors work.
 
   capture.output(base_error <- run_one(placebo, error_type = "base"), type = "message")
-  expect_true("error" %in% names(base_error))
-  expect_match(base_error$error[[1]], "Error.*something went wrong \\(but I knew that\\)")
+  expect_false(is.null(base_error$error))
+  expect_match(base_error$error$log[[1]], "Error.*something went wrong \\(but I knew that\\)")
 
   capture.output(rlang_error <- run_one(placebo, error_type = "rlang::abort"), type = "message")
-  expect_true("error" %in% names(rlang_error))
-  expect_match(paste0(rlang_error$error, collapse = "\n"), "Error.*something went wrong \\(but I knew that\\)")
+  expect_false(is.null(rlang_error$error))
+  expect_match(paste0(rlang_error$error$log, collapse = "\n"), "Error.*something went wrong \\(but I knew that\\)")
 })

--- a/tests/testthat/test-result.R
+++ b/tests/testthat/test-result.R
@@ -23,15 +23,18 @@ test_that("R6.1 classes inherit properly", {
 
 test_that("inherited serialization/deserialization methods work", {
   res <- BenchmarkResult$new(
-    name = "fake",
-    result = data.frame(time = 0, status = "superfast", stringsAsFactors = FALSE),
-    params = list(speed = "lightning"),
-    tags = c(is_real = FALSE)
+    run_name = "fake_run",
+    tags = c(is_real = FALSE),
+    optional_benchmark_info = list(
+      name = "fake",
+      result = data.frame(time = 0, status = "superfast", stringsAsFactors = FALSE),
+      params = list(speed = "lightning")
+    )
   )
 
   # sanity
   expect_s3_class(res, "BenchmarkResult")
-  expect_equal(res$name, "fake")
+  expect_equal(res$run_name, "fake_run")
 
   # roundtrips
   expect_equal(res$json, BenchmarkResult$from_json(res$json)$json)
@@ -45,10 +48,13 @@ test_that("inherited serialization/deserialization methods work", {
 
 test_that("S3 methods work", {
   res <- BenchmarkResult$new(
-    name = "fake",
-    result = data.frame(time = 0, status = "superfast", stringsAsFactors = FALSE),
-    params = list(speed = "lightning"),
-    tags = c(is_real = FALSE)
+    run_name = "fake_run",
+    tags = c(is_real = FALSE),
+    optional_benchmark_info = list(
+      name = "fake",
+      result = data.frame(time = 0, status = "superfast", stringsAsFactors = FALSE),
+      params = list(speed = "lightning")
+    )
   )
 
   expect_equal(as.character(res), res$json)
@@ -59,8 +65,11 @@ test_that("S3 methods work", {
     as.data.frame(res),
     structure(
       list(iteration = 1L, time = 0, status = "superfast", speed = "lightning"),
-      row.names = c(NA, -1L), class = c("tbl_df", "tbl", "data.frame"),
-      name = "fake", tags = c(is_real = FALSE)
+      row.names = c(NA, -1L),
+      class = c("tbl_df", "tbl", "data.frame"),
+      run_name = "fake_run",
+      timestamp = res$timestamp,
+      tags = c(is_real = FALSE)
     )
   )
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -20,7 +20,7 @@ test_that("run_bm", {
   out <- run_bm(b, n_iter = 3)
 
   expect_s3_class(out, "BenchmarkResult")
-  expect_identical(nrow(out$result), 3L)
+  expect_identical(nrow(out$optional_benchmark_info$result), 3L)
 
   expect_error(run_bm(b, param1 = "b"), "isTRUE(result) is not TRUE", fixed = TRUE)
 })
@@ -54,7 +54,7 @@ test_that("cases can be versioned", {
   lapply(res_versioned$results, function(result) {
     expect_true("case_version" %in% names(result$tags))
 
-    expected_version = c(foo = 1L, bar = 2L)[[result$params$x]]
+    expected_version = c(foo = 1L, bar = 2L)[[result$optional_benchmark_info$params$x]]
     expect_equal(result$tags$case_version, expected_version)
   })
 
@@ -154,8 +154,8 @@ test_that("form of the results, including output", {
   ))
 
   json_keys <- c(
-    "name", "tags", "info", "context", "github", "options", "result", "params",
-    "output", "rscript"
+    "batch_id", "timestamp", "stats", "tags", "info", "optional_benchmark_info",
+    "context", "github"
   )
   expect_named(res$results[[1]]$list, json_keys, ignore.order = TRUE)
 
@@ -196,7 +196,7 @@ test_that("an rscript is added to the results object", {
   expect_true(file.exists(res_path))
 
   res <- read_json(res_path)
-  expect_true("rscript" %in% names(res))
+  expect_true("rscript" %in% names(res$optional_benchmark_info))
 })
 
 wipe_results()


### PR DESCRIPTION
This PR changes a number of things, but all with the goal of aligning the JSON results arrowbench outputs with those currently posted to the Conbench API via voltrondata-labs/benchmarks so that eventually arrowbench can post its own results directly.

Changes fall into two categories:

1. Changes to result structure to align with the `/api/benchmarks/` endpoint
2. Changes to benchmarks so the data that populates results aligns with what labs/benchmarks generates. This has only been done for [the set of benchmarks run by arrow-benchmarks-ci](https://github.com/voltrondata-labs/arrow-benchmarks-ci/blob/0e4e2f4fb43adc22bf6f6c6beddbbb7881d557b5/config.py#L86-L91).

This PR cannot be merged until https://github.com/voltrondata-labs/benchmarks/pull/122 is merged, or it will break current arrow benchmarks. That PR contains code to handle changes to assorted names and parameter names here. It has been tested with that branch.