### PR TITLE
Use the duckdb answers for now

### DIFF
--- a/R/bm-tpc-h.R
+++ b/R/bm-tpc-h.R
@@ -366,7 +366,7 @@ tpch_answer <- function(scale_factor, query_id, source = c("arrowbench", "duckdb
     }
   }
 
-  tibble::as_tibble(answer)
+  answer
 }
 
 #' Get a SQL query

--- a/R/bm-tpc-h.R
+++ b/R/bm-tpc-h.R
@@ -91,6 +91,7 @@ tpc_h <- Benchmark("tpc_h",
   after_each = {
     # If the scale_factor is < 1, duckdb has the answer
     if (scale_factor %in% c(0.01, 0.1, 1, 10)) {
+      # change the source to be arrow
       answer <- tpch_answer(scale_factor, query_id)
 
       # the result is sometimes a data.frame, turn into a tibble for printing
@@ -296,17 +297,28 @@ get_query_func <- function(query_id, engine = NULL) {
 #' @param query_id Id of the query (possible values: 1-22)
 #' @param source source of the answer (default: "arrowbench"), "duckdb" can
 #' return answers for scale_factor 1.
+#' @param data_source which source of data should we construct ansers for? "duckdb"
+#' (the default) has a slightly different set of data in the *_address columns
+#' compared to "dbgen"
 #'
 #' @return the answer, as a data.frame
 #' @export
-tpch_answer <- function(scale_factor, query_id, source = c("arrowbench", "duckdb")) {
+tpch_answer <- function(scale_factor, query_id, source = c("arrowbench", "duckdb"), data_source = c("duckdb", "dbgen")) {
   source <- match.arg(source)
 
   if (source == "arrowbench") {
     scale_factor_string <- format(scale_factor, scientific = FALSE)
+
+    # data generated from duckdb have sliiiightly different *_addresses
+    if (match.arg(data_source) == "duckdb") {
+      data_source_dir <- "answers_duckdb_data"
+    } else {
+      data_source_dir <- "answers"
+    }
+
     answer_file <- system.file(
       "tpch",
-      "answers",
+      data_source_dir,
       paste0("scale-factor-", scale_factor_string),
       paste0("tpch-q", sprintf("%02i", query_id), "-sf", scale_factor_string, ".parquet"),
       package = "arrowbench"
@@ -354,7 +366,7 @@ tpch_answer <- function(scale_factor, query_id, source = c("arrowbench", "duckdb
     }
   }
 
-  answer
+  tibble::as_tibble(answer)
 }
 
 #' Get a SQL query

--- a/R/bm-tpc-h.R
+++ b/R/bm-tpc-h.R
@@ -91,7 +91,6 @@ tpc_h <- Benchmark("tpc_h",
   after_each = {
     # If the scale_factor is < 1, duckdb has the answer
     if (scale_factor %in% c(0.01, 0.1, 1, 10)) {
-      # change the source to be arrow
       answer <- tpch_answer(scale_factor, query_id)
 
       # the result is sometimes a data.frame, turn into a tibble for printing

--- a/man/tpch_answer.Rd
+++ b/man/tpch_answer.Rd
@@ -4,7 +4,12 @@
 \alias{tpch_answer}
 \title{Get a TPC-H answer}
 \usage{
-tpch_answer(scale_factor, query_id, source = c("arrowbench", "duckdb"))
+tpch_answer(
+  scale_factor,
+  query_id,
+  source = c("arrowbench", "duckdb"),
+  data_source = c("duckdb", "dbgen")
+)
 }
 \arguments{
 \item{scale_factor}{scale factor (possible values: \code{c(0.01, 0.1, 1, 10)})}
@@ -13,6 +18,10 @@ tpch_answer(scale_factor, query_id, source = c("arrowbench", "duckdb"))
 
 \item{source}{source of the answer (default: "arrowbench"), "duckdb" can
 return answers for scale_factor 1.}
+
+\item{data_source}{which source of data should we construct ansers for? "duckdb"
+(the default) has a slightly different set of data in the *_address columns
+compared to "dbgen"}
 }
 \value{
 the answer, as a data.frame


### PR DESCRIPTION
#117 defaulted to the dbgen-based answers, but we aren't quite ready for this. This has caused a handful of validation errors on the Arrow benchmarks (cf https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-ursa-i9-9960x/builds/1954#0184d135-bc6a-4d81-b45d-d43ccbea307a)