### PR TITLE
Fix parentheses/quotation in documents

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -72,7 +72,7 @@ bm_run_cache_key <- function(name, ...) {
 
 #' Confirm that the memory allocator enabled
 #'
-#' @param mem_alloc the memory allocator to be tested (one of: "jemalloc", "mimalloc", "system)
+#' @param mem_alloc the memory allocator to be tested (one of: "jemalloc", "mimalloc", "system")
 #'
 #' @return nothing
 #' @export

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ new_csv_benchmark <- Benchmark(
   # to setup case- or source-specific properties (see `result_dim` below).
   setup = function(source = names(known_sources),
                    as_data_frame = c(TRUE, FALSE),
-                   skip_empty_rows = TRUE)) {
+                   skip_empty_rows = TRUE) {
     # Validate the parameters
     # For our benchmark: as_data_frame defaults to TRUE and FALSE (so if it is 
     # unspecified you will get both TRUE and FALSE in the benchmark matrix)

--- a/man/confirm_mem_alloc.Rd
+++ b/man/confirm_mem_alloc.Rd
@@ -7,7 +7,7 @@
 confirm_mem_alloc(mem_alloc)
 }
 \arguments{
-\item{mem_alloc}{the memory allocator to be tested (one of: "jemalloc", "mimalloc", "system)}
+\item{mem_alloc}{the memory allocator to be tested (one of: "jemalloc", "mimalloc", "system")}
 }
 \value{
 nothing


### PR DESCRIPTION
I found this useful package and tried the examples in the README. The following error occurred when executing the code listed in the `A (contrived) example` section.

```
Error: unexpected ')' in:
"                     as_data_frame = c(TRUE, FALSE),
                     skip_empty_rows = TRUE))"
```

This is due to the extra parentheses, which are fixed in this PR.
In addition, I have also corrected a forgotten closing of parentheses in the Rd.