### PR TITLE
Handle missing `output` param in tpc_h

### DIFF
--- a/R/bm-tpc-h.R
+++ b/R/bm-tpc-h.R
@@ -144,7 +144,11 @@ tpc_h <- Benchmark("tpch",
   tags_fun = function(params) {
     # for consistency with runs through voltrondata-labs/benchmarks
     params$query_id <- sprintf("TPCH-%02d", params$query_id)
-    if (params$output == "data_frame") {
+    # TODO / NOTE: `params$output` may be NULL if not specified in a call to
+    # `run_one()` as voltrondata-labs/benchmarks does.
+    # [arrowbench#129](https://github.com/voltrondata-labs/arrowbench/issues/129)
+    # will fix this, at which point the first condition here should be removed.
+    if (!is.null(params$output) && params$output == "data_frame") {
       params$output <- NULL
     }
     params


### PR DESCRIPTION
In `tpc_h`'s `tags_fun()`, `params$output` is missing when called from voltrondata-labs/benchmarks because it relies on the default of `"data_frame"`, which `run_one()` does not populate (see #129). This gets things running for now until we can fix that larger issue, which has the potential to break histories.