### PR TITLE
Add benchmarks.json file for arrow-benchmarks-ci

### DIFF
--- a/inst/benchmarks.json
+++ b/inst/benchmarks.json
@@ -1,0 +1,86 @@
+[
+  {
+    "lang": "R",
+    "command": "dataset_taxi_2013",
+    "name": "dataset_taxi_2013",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "row_group_size",
+    "name": "row_group_size",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "write_csv",
+    "name": "write_csv",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "read_csv",
+    "name": "read_csv",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "read_json",
+    "name": "read_json",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "remote_dataset",
+    "name": "remote_dataset",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "file-write",
+    "name": "file-write",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "dataframe-to-table",
+    "name": "dataframe-to-table",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "table_to_df",
+    "name": "table_to_df",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "array_to_vector",
+    "name": "array_to_vector",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "partitioned-dataset-filter",
+    "name": "partitioned-dataset-filter",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "file-read",
+    "name": "file-read",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "tpch",
+    "name": "tpch",
+    "runner": "arrowbench"
+  },
+  {
+    "lang": "R",
+    "command": "array_altrep_materialization",
+    "name": "array_altrep_materialization",
+    "runner": "arrowbench"
+  }
+]

--- a/inst/benchmarks.json
+++ b/inst/benchmarks.json
@@ -1,7 +1,7 @@
 [
   {
     "command": "dataset_taxi_2013",
-    "name": "dataset_taxi_2013",
+    "name": "arrowbench/dataset_taxi_2013",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -9,7 +9,7 @@
   },
   {
     "command": "row_group_size",
-    "name": "row_group_size",
+    "name": "arrowbench/row_group_size",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -17,7 +17,7 @@
   },
   {
     "command": "write_csv",
-    "name": "write_csv",
+    "name": "arrowbench/write_csv",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -25,7 +25,7 @@
   },
   {
     "command": "read_csv",
-    "name": "read_csv",
+    "name": "arrowbench/read_csv",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -33,7 +33,7 @@
   },
   {
     "command": "read_json",
-    "name": "read_json",
+    "name": "arrowbench/read_json",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -41,7 +41,7 @@
   },
   {
     "command": "remote_dataset",
-    "name": "remote_dataset",
+    "name": "arrowbench/remote_dataset",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -49,7 +49,7 @@
   },
   {
     "command": "file-write",
-    "name": "file-write",
+    "name": "arrowbench/file-write",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -57,7 +57,7 @@
   },
   {
     "command": "dataframe-to-table",
-    "name": "dataframe-to-table",
+    "name": "arrowbench/dataframe-to-table",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -65,7 +65,7 @@
   },
   {
     "command": "table_to_df",
-    "name": "table_to_df",
+    "name": "arrowbench/table_to_df",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -73,7 +73,7 @@
   },
   {
     "command": "array_to_vector",
-    "name": "array_to_vector",
+    "name": "arrowbench/array_to_vector",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -81,7 +81,7 @@
   },
   {
     "command": "partitioned-dataset-filter",
-    "name": "partitioned-dataset-filter",
+    "name": "arrowbench/partitioned-dataset-filter",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -89,7 +89,7 @@
   },
   {
     "command": "file-read",
-    "name": "file-read",
+    "name": "arrowbench/file-read",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -97,7 +97,7 @@
   },
   {
     "command": "tpch",
-    "name": "tpch",
+    "name": "arrowbench/tpch",
     "runner": "arrowbench",
     "flags": {
       "language": "R"
@@ -105,7 +105,7 @@
   },
   {
     "command": "array_altrep_materialization",
-    "name": "array_altrep_materialization",
+    "name": "arrowbench/array_altrep_materialization",
     "runner": "arrowbench",
     "flags": {
       "language": "R"

--- a/inst/benchmarks.json
+++ b/inst/benchmarks.json
@@ -1,86 +1,114 @@
 [
   {
-    "lang": "R",
     "command": "dataset_taxi_2013",
     "name": "dataset_taxi_2013",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "row_group_size",
     "name": "row_group_size",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "write_csv",
     "name": "write_csv",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "read_csv",
     "name": "read_csv",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "read_json",
     "name": "read_json",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "remote_dataset",
     "name": "remote_dataset",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "file-write",
     "name": "file-write",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "dataframe-to-table",
     "name": "dataframe-to-table",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "table_to_df",
     "name": "table_to_df",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "array_to_vector",
     "name": "array_to_vector",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "partitioned-dataset-filter",
     "name": "partitioned-dataset-filter",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "file-read",
     "name": "file-read",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "tpch",
     "name": "tpch",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   },
   {
-    "lang": "R",
     "command": "array_altrep_materialization",
     "name": "array_altrep_materialization",
-    "runner": "arrowbench"
+    "runner": "arrowbench",
+    "flags": {
+      "language": "R"
+    }
   }
 ]

--- a/inst/regenerate-benchmarks-json.R
+++ b/inst/regenerate-benchmarks-json.R
@@ -1,0 +1,22 @@
+"
+This script regenerates inst/benchmarks.json with all current benchmarks. That
+file is used by arrow-benchmarks-ci here:
+https://github.com/voltrondata-labs/arrow-benchmarks-ci/blob/main/buildkite/benchmark/run.py
+to keep track of benchmarks available in a repository.
+"
+
+arrowbench::get_package_benchmarks()$name |>
+  lapply(function(name) {
+    list(
+      lang = "R",
+      command = name,
+      name = name,
+      runner = "arrowbench"
+    )
+  }) |>
+  unname() |>
+  jsonlite::write_json(
+    path = "inst/benchmarks.json",
+    pretty = TRUE,
+    auto_unbox = TRUE
+  )

--- a/inst/regenerate-benchmarks-json.R
+++ b/inst/regenerate-benchmarks-json.R
@@ -8,10 +8,10 @@ to keep track of benchmarks available in a repository.
 arrowbench::get_package_benchmarks()$name |>
   lapply(function(name) {
     list(
-      lang = "R",
       command = name,
       name = name,
-      runner = "arrowbench"
+      runner = "arrowbench",
+      flags = list(language = "R")
     )
   }) |>
   unname() |>

--- a/inst/regenerate-benchmarks-json.R
+++ b/inst/regenerate-benchmarks-json.R
@@ -9,7 +9,7 @@ arrowbench::get_package_benchmarks()$name |>
   lapply(function(name) {
     list(
       command = name,
-      name = name,
+      name = paste0("arrowbench/", name),
       runner = "arrowbench",
       flags = list(language = "R")
     )


### PR DESCRIPTION
Adds benchmarks.json metadata file (and a little script to regenerate it if necessary) so arrow-benchmarks-ci can see what benchmarks are available in this repo.