### PR TITLE
Let `run_id` be manually specified in runners

### DIFF
--- a/man/run.Rd
+++ b/man/run.Rd
@@ -7,7 +7,7 @@
 \usage{
 run(x, ...)
 
-\method{run}{BenchmarkDataFrame}(x, ..., publish = FALSE, run_name = NULL, run_reason = NULL)
+\method{run}{BenchmarkDataFrame}(x, ..., publish = FALSE, run_id = NULL, run_name = NULL, run_reason = NULL)
 }
 \arguments{
 \item{x}{An S3 classed object to run}
@@ -19,6 +19,8 @@ parameters are not specified) and \code{\link[=run_benchmark]{run_benchmark()}}.
 \item{publish}{Flag for whether to publish results to a Conbench server. See
 "Environment Variables" section for how to specify server details. Requires
 the benchconnect CLI is installed; see \code{\link[=install_benchconnect]{install_benchconnect()}}.}
+
+\item{run_id}{Unique ID for the run. If not specified, will be generated.}
 
 \item{run_name}{Name for the run. If not specified, will use \verb{\{run_reason\}: \{commit hash\}}}
 

--- a/man/run_benchmark.Rd
+++ b/man/run_benchmark.Rd
@@ -12,6 +12,7 @@ run_benchmark(
   dry_run = FALSE,
   profiling = FALSE,
   read_only = FALSE,
+  run_id = NULL,
   run_name = NULL,
   run_reason = NULL
 )
@@ -37,6 +38,8 @@ contain a \code{prof_file} field, which you can read in with
 
 \item{read_only}{this will only attempt to read benchmark files and will not
 run any that it cannot find.}
+
+\item{run_id}{Unique ID for the run}
 
 \item{run_name}{Name for the run. If not specified, will use \verb{\{run_reason\}: \{commit hash\}}}
 

--- a/man/run_bm.Rd
+++ b/man/run_bm.Rd
@@ -11,6 +11,7 @@ run_bm(
   batch_id = NULL,
   profiling = FALSE,
   global_params = list(),
+  run_id = NULL,
   run_name = NULL,
   run_reason = NULL
 )
@@ -29,6 +30,8 @@ contain a \code{prof_file} field, which you can read in with
 \code{profvis::profvis(prof_input = file)}. Default is \code{FALSE}}
 
 \item{global_params}{the global parameters that have been set}
+
+\item{run_id}{Unique ID for the run}
 
 \item{run_name}{Name for the run}
 

--- a/man/run_one.Rd
+++ b/man/run_one.Rd
@@ -13,6 +13,7 @@ run_one(
   profiling = FALSE,
   progress_bar = NULL,
   read_only = FALSE,
+  run_id = NULL,
   run_name = NULL,
   run_reason = NULL,
   test_packages = NULL
@@ -38,6 +39,8 @@ contain a \code{prof_file} field, which you can read in with
 
 \item{read_only}{this will only attempt to read benchmark files and will not
 run any that it cannot find.}
+
+\item{run_id}{Unique ID for the run}
 
 \item{run_name}{Name for the run}
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -313,6 +313,7 @@ test_that("run.BenchmarkDataFrame() with `publish = TRUE` works (with mocking)",
     commit = "2z8c9c49a5dc4a179243268e4bb6daa5",
     pr_number = 47L
   )
+  run_id <- "fake-run-id"
   run_reason <- "mocked-arrowbench-unit-test"
   run_name <- paste(run_reason, github$commit, sep = ": ")
   host_name <- "fake-computer"
@@ -336,6 +337,7 @@ test_that("run.BenchmarkDataFrame() with `publish = TRUE` works (with mocking)",
             how = function(run) {
               run <- augment_run(run)
               expect_identical(run$github, github)
+              expect_identical(run$id, run_id)
               expect_identical(run$name, run_name)
               expect_identical(run$reason, run_reason)
               expect_identical(run$machine_info$name, host_name)
@@ -347,6 +349,7 @@ test_that("run.BenchmarkDataFrame() with `publish = TRUE` works (with mocking)",
             what = "submit_result",
             how = function(result) {
               expect_identical(result$github, github)
+              expect_identical(result$run_id, run_id)
               expect_identical(result$run_name, run_name)
               expect_identical(result$run_reason, run_reason)
               expect_identical(result$machine_info$name, host_name)
@@ -359,6 +362,7 @@ test_that("run.BenchmarkDataFrame() with `publish = TRUE` works (with mocking)",
             how = function(run) {
               run <- augment_run(run)
               expect_identical(run$github, github)
+              expect_identical(run$id, run_id)
               expect_identical(run$name, run_name)
               expect_identical(run$reason, run_reason)
               expect_identical(run$machine_info$name, host_name)
@@ -369,6 +373,7 @@ test_that("run.BenchmarkDataFrame() with `publish = TRUE` works (with mocking)",
           bm_df_res <- run(
             bm_df,
             publish = TRUE,
+            run_id = run_id,
             run_name = run_name,
             run_reason = run_reason
 


### PR DESCRIPTION
Closes #132 by adding a `run_id` parameter to `run.BenchmarkDataFrame` and cascading it through the runner functions like `run_name` and `run_reason`. Will let arrow-benchmarks-ci specify `run_id`, but if a user calls `run(my_bm_df)` without specifying it, it will continue to generate one via benchconnect.