### PR TITLE
Return errored results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     RcppSimdJson,
     readr,
     vroom
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE, load = "source")
 Collate: 
     'benchmark-dataframe.R'

--- a/R/measure.R
+++ b/R/measure.R
@@ -45,6 +45,7 @@ with_profiling <- function(profiling_on, expr) {
 }
 
 with_gc_info <- function(expr) {
+  force(expr)
   with_gcinfo <- "bench" %:::% "with_gcinfo"
   gc_output <- with_gcinfo(eval.parent(expr))
   # This will swallow errors, so check for error output and re-raise

--- a/R/result.R
+++ b/R/result.R
@@ -91,6 +91,9 @@ Serializable <- R6Point1Class(
 
   public = list(
     write_json = function(path) {
+      if (!dir.exists(dirname(path))) {
+        dir.create(dirname(path), recursive = TRUE)
+      }
       writeLines(self$json, path)
     }
   ),

--- a/R/run.R
+++ b/R/run.R
@@ -367,7 +367,7 @@ run_bm <- function(bm, ..., n_iter = 1, batch_id = NULL, profiling = FALSE,
         }
       ),
       error = function(e){
-        # Note: this will only capture the last error
+        # Note: this will only capture the error from the last erroring iteration
         error <<- list(
           error = as.character(e),
           stack_trace = vapply(

--- a/R/run.R
+++ b/R/run.R
@@ -308,12 +308,6 @@ run_one <- function(bm,
   )
   result <- do.call(run_script, run_script_args)
 
-  if (!identical(Sys.getenv("TESTTHAT"), "true") && !is.null(result$error)) {
-    cat("Result errored; quitting with status = 1")
-    cat(result$error)
-    quit(status = 1L)
-  }
-
   result
 }
 

--- a/R/run.R
+++ b/R/run.R
@@ -662,7 +662,6 @@ run_script <- function(lines, cmd = find_r(), ..., metadata, progress_bar, read_
     )
   }
 
-  result <- augment_result(result)
   result$write_json(file)
 
   if (!is.null(progress_bar)) {

--- a/R/util.R
+++ b/R/util.R
@@ -64,6 +64,7 @@ file_with_ext <- function(file, new_ext) {
 
 bm_run_cache_key <- function(name, ...) {
   dots <- list(...)
+  dots <- lapply(dots, function(x) if (is.null(x)) "NULL" else x)
   # redact any slashes from the dots since they will not save correctly
   dots <- lapply(dots, gsub, pattern = "/", replacement = "_")
   dots <- dots[sort(names(dots))]

--- a/tests/testthat/test-measure.R
+++ b/tests/testthat/test-measure.R
@@ -8,7 +8,7 @@ test_that("with_gc_info + errors", {
     )
   )
   expect_false(is.null(base_error$error))
-  expect_match(base_error$error$log[[1]], "Error.*something went wrong \\(but I knew that\\)")
+  expect_match(base_error$error$error, "Error.*something went wrong \\(but I knew that\\)")
 
   suppress_deparse_warning(
     capture.output(
@@ -16,5 +16,5 @@ test_that("with_gc_info + errors", {
     )
   )
   expect_false(is.null(base_error$error))
-  expect_match(paste0(rlang_error$error$log, collapse = "\n"), "Error.*something went wrong \\(but I knew that\\)")
+  expect_match(rlang_error$error$error, "Error.*something went wrong \\(but I knew that\\)")
 })

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -119,7 +119,8 @@ test_that("Argument validation", {
 
   suppress_deparse_warning(
     expect_message(
-      run_one(placebo, cpu_count = 1)
+      run_one(placebo, cpu_count = 1),
+      NA
     )
   )
 
@@ -131,7 +132,8 @@ test_that("Path validation and redaction", {
   # the one being tested (e.g. when using devtools::test())
   suppress_deparse_warning(
     expect_message(
-      run_one(placebo, cpu_count = 1, grid = "not/a/file@path")
+      run_one(placebo, cpu_count = 1, grid = "not/a/file@path"),
+      NA
     )
   )
 
@@ -186,8 +188,8 @@ test_that("form of the results, including output", {
   ))
 
   json_keys <- c(
-    'batch_id', 'context', 'github', 'info', 'machine_info',
-    'optional_benchmark_info', 'run_name', 'stats', 'tags', 'timestamp'
+    "batch_id", "timestamp", "stats", "tags", "info", "optional_benchmark_info",
+    "context", "github"
   )
   expect_named(res$results[[1]]$list, json_keys, ignore.order = TRUE)
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -41,10 +41,10 @@ test_that("sync_and_drop_caches() works", {
     }
   }
 
-  cases = purrr::cross(list(
+  cases = suppressWarnings(purrr::cross(list(
     "sync; echo 3 | sudo tee /proc/sys/vm/drop_caches" = c(TRUE, FALSE),
     "sync; sudo purge" = c(TRUE, FALSE)
-  ))
+  )))
 
   for (case in cases) {
     options(


### PR DESCRIPTION
Necessary for addressing https://github.com/voltrondata-labs/benchmarks/issues/134; a separate (coming) labs/benchmarks PR will be necessary to pick up all the data this is now sending properly.

The prime focus of this PR is to catch errors during iterations properly and write the results just like we do for non-errored benchmarks. Along the way this addresses some issues this uncovered, and makes a few judgment calls about what goes where, so comments are welcome!